### PR TITLE
More flexible behavior for one child in hier-select mode

### DIFF
--- a/src/jquery.fancytree.js
+++ b/src/jquery.fancytree.js
@@ -806,7 +806,7 @@ FancytreeNode.prototype = /** @lends FancytreeNode# */{
 		this.visitParents(function(node){
 			var i, l, child, state, unselIgnore, unselState,
 				children = node.children,
-				allSelected = true,
+				allSelected = (children.length > 1),
 				someSelected = false;
 
 			for( i=0, l=children.length; i<l; i++ ){


### PR DESCRIPTION
In hier-select mode when parent node has only one child node user can't select explicity child nod, but now he can do it